### PR TITLE
🛠 fix: Ignore `power_bookmark_meta` key in `meta_info`

### DIFF
--- a/src/bookmarks_converter/models.py
+++ b/src/bookmarks_converter/models.py
@@ -289,7 +289,7 @@ class JSONBookmark(NodeMixin):
         # Chrome has added a new field in their json file `meta_info`.
         # This field is a dictionary with key/value pairs.
         # ignore this field for the time being as it only contains `last_visited_desktop` key.
-        if "last_visited_desktop" in kwargs:
+        if any(k in kwargs for k in ["last_visited_desktop", "power_bookmark_meta"]):
             return
 
         # check the version of the passed json file depending on unique elements


### PR DESCRIPTION
`power_bookmark_meta` is a new key added to `meta_info`, which will break the parsing function.

Here is an example: 

```json
{
  "date_added": "13321806863393667",
  "date_last_used": "0",
  "guid": "fdba9425-26d7-4d91-a7b3-959e8171c229",
  "id": "4036",
  "meta_info": {
    "power_bookmark_meta": ""
  },
  "name": "Read CV",
  "type": "url",
  "url": "https://read.cv/"
},
```

This PR will fix the bug.